### PR TITLE
feat: Add Interface RuleSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can check out all our samples at the [samples directory](./samples/)! Lookin
 
 ### 💭 Someday
 
-+ [ ] Allow for random generation of interfaces (*aka inputs don't need to be a class*)
++ [X] Allow for random generation of interfaces (*aka inputs don't need to be a class*)
 + [ ] Allow recursive generation (*aka we can handle nested objects*)
 + [ ] Allow customization of the generation strategy (*aka consumers can tweak how we generate objects*)
 + [ ] Create a Builder/Fluent API (*aka allow consumers to chain customization calls*)

--- a/samples/secondVersion.ts
+++ b/samples/secondVersion.ts
@@ -2,13 +2,19 @@ import {
   dixtureFns,
   RuleSet,
   DixtureFactory,
-} from "https://deno.land/x/dixture@v0.2.0/mod.ts";
+  InterfaceRuleSet,
+} from "../src/mod.ts";
 
 class Person {
   name: string = "";
   age: number = 0;
   bankBalance: bigint = 1n;
   isAlive: boolean = true;
+}
+
+interface DateRange {
+  startsAt: Date;
+  endsAt: Date;
 }
 
 // 1. Creating our factory
@@ -32,15 +38,32 @@ const factory = new DixtureFactory(
         }
         return 0n;
       },
-    }, // 5. We can also omit rules, the field might not be important after all
+    }, // 5. We can also omit rules, the field might not be important after all,
+  ),
+  // 6. We also handle interfaces!
+  new InterfaceRuleSet<DateRange>(
+    "DateRange", // 7. Set a key so we can resolve your interface later down the road
+    // 8. And describe its rules
+    {
+      field: "startsAt",
+      resolve: () => new Date(),
+    },
+    {
+      field: "endsAt",
+      resolve: () => (new Date(Date.now() + 1000 * 60 * 60 * 24 * 3)),
+    },
   ),
 );
 
-// 6. After everything is done just call build(YourClass)
+// 9. After everything is done just call build(YourClass)
 const { age, bankBalance, name } = factory.build(Person);
 console.table([age, bankBalance, name]);
 
-// 7. Enjoy setting your rules only once!
+// 10. Or build<YourInterface>(yourInterfaceKey);
+const { startsAt, endsAt } = factory.build<DateRange>("DateRange");
+console.table([startsAt.toLocaleDateString(), endsAt.toLocaleDateString()]);
+
+// 11. Enjoy setting your rules only once!
 /**
   * ┌───────┬─────────────────────┐
   * │ (idx) │       Values        │
@@ -49,4 +72,12 @@ console.table([age, bankBalance, name]);
   * │   1   │      10000000n      │
   * │   2   │ "745.5967546042531" │
   * └───────┴─────────────────────┘
+ */
+/**
+ * ┌───────┬───────────────────┐
+ * │ (idx) │      Values       │
+ * ├───────┼───────────────────┤
+ * │   0   │ "Mon Sep 14 2020" │
+ * │   1   │ "Thu Sep 17 2020" │
+ * └───────┴───────────────────┘
  */

--- a/src/_factory.ts
+++ b/src/_factory.ts
@@ -63,32 +63,34 @@ interface RuleFor<T, K extends keyof T> {
 }
 
 /**
- * Describes a rule set (a blueprint) for creating a class.
+ * Describes the common logic for a Rule Set.
  */
-export class RuleSet<T> {
-  /**
-   * Name of the class created by this blueprint.
-   */
-  public readonly name: string;
-
+abstract class BaseRuleSet<T> {
   /**
    * Rules for each field of the class.
    */
   protected readonly rules: RuleFor<T, keyof T>[];
 
-  constructor(
-    protected readonly ctor: Constructable<T>,
+  /**
+   * Creates a dummy for constructing a subject.
+   */
+  protected abstract createDummy(): T;
+
+  /**
+   * Creates a new Rule Set.
+   */
+  protected constructor(
+    public readonly name: string,
     ...args: RuleFor<T, keyof T>[]
   ) {
-    this.name = ctor.name;
     this.rules = args;
   }
 
   /**
    * Builds a new instance of the class using the defined rules.
    */
-  build(): T {
-    const result = new this.ctor();
+  public build(): T {
+    const result = this.createDummy();
     this.rules.forEach((r) => {
       const { field, resolve } = r;
       result[field] = resolve();
@@ -98,33 +100,73 @@ export class RuleSet<T> {
 }
 
 /**
- * A factory for instances of a class.
+ * Describes a rule set (a blueprint) for creating a class.
+ */
+export class RuleSet<T> extends BaseRuleSet<T> {
+  protected createDummy(): T {
+    return new this.ctor();
+  }
+
+  constructor(
+    protected readonly ctor: Constructable<T>,
+    ...args: RuleFor<T, keyof T>[]
+  ) {
+    super(ctor.name, ...args);
+  }
+}
+
+/**
+ * Describes a rule set (a blueprint) for creating an Interface.
+ */
+export class InterfaceRuleSet<T> extends BaseRuleSet<T> {
+  protected createDummy(): T {
+    return {} as T;
+  }
+
+  constructor(name: string, ...args: RuleFor<T, keyof T>[]) {
+    super(name, ...args);
+  }
+}
+
+/**
+ * A factory for instances of a class/interface.
  */
 export class DixtureFactory {
   /**
    * Rule Sets for the Factory.
    */
-  protected readonly ruleSets: RuleSet<any>[] = [];
+  protected readonly ruleSets: BaseRuleSet<any>[] = [];
 
-  constructor(...args: RuleSet<any>[]) {
+  constructor(...args: BaseRuleSet<any>[]) {
     this.ruleSets = args;
   }
 
   /**
-   * Adds a new ruleset into the existing ruleset collection.
+   * Adds a new Rule Set into the existing collection.
    * @param ruleSet rule set (blueprint) to be added
    */
-  addRuleSet<T>(ruleSet: RuleSet<T>) {
+  addRuleSet<T>(ruleSet: BaseRuleSet<T>) {
     this.ruleSets.push(ruleSet);
   }
 
   /**
-   * Creates a new instance of a class using the available blueprints.
-   * @param ctor class to be created
+   * Creates a new instance of a class/interface using the available blueprints.
+   * @param ctor class/interface to be created
    */
-  build<T>(ctor: Constructable<T>): T {
+  build<T>(ctor: Constructable<T> | string): T {
+    const rulesetKey = typeof ctor === "function"
+      ? this.fetchKeyForClass(ctor)
+      : ctor;
     const result = this.ruleSets
-      .filter((r) => r.name == ctor.name)[0]?.build();
+      .filter((r) => r.name === rulesetKey)[0]?.build();
     return result as T;
+  }
+
+  /**
+   * Fetches the ruleset's key from a class.
+   * @param ctor constructor of a class
+   */
+  protected fetchKeyForClass<T>(ctor: Constructable<T>): string {
+    return ctor.name;
   }
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -10,6 +10,7 @@ export { create } from "./_autoGenerator.ts";
 export {
   dixtureFns,
   GenerationFunctions,
+  InterfaceRuleSet,
   RuleSet,
   DixtureFactory,
 } from "./_factory.ts";

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -5,5 +5,5 @@ export {
   assertEquals,
   assertThrows,
   assertStringContains,
-  fail
+  fail,
 } from "https://deno.land/std/testing/asserts.ts";

--- a/tests/factory_test.ts
+++ b/tests/factory_test.ts
@@ -1,5 +1,15 @@
 import { Rhum, assert, fail } from "./deps.ts";
-import { DixtureFactory, RuleSet, dixtureFns } from "../src/_factory.ts";
+import {
+  DixtureFactory,
+  RuleSet,
+  dixtureFns,
+  InterfaceRuleSet,
+} from "../src/_factory.ts";
+
+interface JustAnotherSubject {
+  name: string;
+  goodThru: Date;
+}
 
 /**
  * Say my name... I guess?
@@ -166,6 +176,91 @@ Rhum.testPlan("Factories", () => {
         const result = factory.build(MyOtherSubject);
         assert(result instanceof MyOtherSubject);
         assert(bigIntNum !== result.bigIntNum);
+      },
+    );
+
+    Rhum.testCase(
+      "6. Should build interfaces using their rulesets",
+      () => {
+        const interfaceKey = "just-another-object-in-the-wall";
+        const factory = new DixtureFactory(
+          new InterfaceRuleSet<JustAnotherSubject>(interfaceKey, {
+            field: "goodThru",
+            resolve: () => new Date(),
+          }, {
+            field: "name",
+            resolve: dixtureFns.String,
+          }),
+        );
+
+        const result = factory.build<JustAnotherSubject>(interfaceKey);
+        assert(result != null);
+        assert(result.goodThru != null);
+        assert(result.name != null);
+      },
+    );
+  });
+
+  Rhum.testSuite("3. InterfaceRuleSet<T>", () => {
+    const justAnotherSubjectKey = "jasubject";
+    Rhum.testCase(
+      "1. Should be constructable without rules",
+      () => {
+        try {
+          new InterfaceRuleSet<JustAnotherSubject>(justAnotherSubjectKey);
+        } catch (error) {
+          fail(`Creation failed with error ${error}`);
+        }
+      },
+    );
+
+    Rhum.testCase(
+      "2. Should allow rules with builtin resolves",
+      () => {
+        const subject = new InterfaceRuleSet<JustAnotherSubject>(
+          justAnotherSubjectKey,
+          {
+            field: "name",
+            resolve: dixtureFns.String,
+          },
+        );
+        const result = subject.build();
+        assert(result.name != null);
+      },
+    );
+
+    Rhum.testCase(
+      "3. Should allow rules with custom resolves",
+      () => {
+        const subject = new InterfaceRuleSet<JustAnotherSubject>(
+          justAnotherSubjectKey,
+          {
+            field: "name",
+            resolve: () => "Walter White",
+          },
+        );
+        const result = subject.build();
+        assert(result.name != null, "We are goddamn wrong... I guess");
+      },
+    );
+
+    Rhum.testCase(
+      "4. Should allow rules with mixed resolves",
+      () => {
+        const subject = new InterfaceRuleSet<JustAnotherSubject>(
+          justAnotherSubjectKey,
+          {
+            field: "name",
+            resolve: () => "Walter White",
+          },
+          {
+            field: "goodThru",
+            resolve: () => new Date(dixtureFns.Int()),
+          },
+        );
+        const result = subject.build();
+        assert(result.goodThru != null);
+        assert(result.name != null);
       },
     );
   });


### PR DESCRIPTION
This commit allow us to leverage the DixtureFactory for building
interfaces as well!
Also squashes the following:

+ refactor: Destructure during foreach
+ refactor: Extract common logic into a BaseRuleSet
+ refactor: Change DixtureFactory from RuleSets into BaseRuleSets
+ refactor: Cleanup RuleSet<T>
+ feat: Add Interface RuleSets
+ fix: Handle interfaces on DixtureFactory
+ chore: Update secondVersion samples with Interface Ruleset