### PR TITLE
feat: Add Past and Future Dates to dixtureFns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thus I began working on this project.
 
 Simply import us by `deno.land/x/` and use your favorite flavor of test data generation!
 
-*As of v0.2.0* you can pick from two "flavors":
+*As of v0.2.1* you can pick from two "flavors":
 
 1. Functions that create and/or assign fields for your classes and instances
 2. A Factory API that allows you to write down rules for your classes
@@ -80,7 +80,7 @@ const factory = new DixtureFactory(
     },
     {
       field: "endsAt",
-      resolve: () => (new Date(Date.now() + 1000 * 60 * 60 * 24 * 3)),
+      resolve: dixtureFns.FutureDate,
     },
   ),
 );
@@ -131,6 +131,10 @@ You can check out all our samples at the [samples directory](./samples/)! Lookin
 ### 🍾 v0.2.1
 
 + [X] Allow for random generation of interfaces (*aka inputs don't need to be a class*)
+
+### 🍔 v0.2.2
+
++ [X] Allow for random generation of dates (*aka we can generate future and past dates for consumers*)
 
 ### 🌊 v0.3.0
 

--- a/samples/secondVersion.ts
+++ b/samples/secondVersion.ts
@@ -50,7 +50,7 @@ const factory = new DixtureFactory(
     },
     {
       field: "endsAt",
-      resolve: () => (new Date(Date.now() + 1000 * 60 * 60 * 24 * 3)),
+      resolve: dixtureFns.FutureDate,
     },
   ),
 );

--- a/src/_factory.ts
+++ b/src/_factory.ts
@@ -3,6 +3,7 @@ import {
   createBoolean,
   createNumber,
   createString,
+  createDate,
 } from "./_simpleGenerator.ts";
 
 /**
@@ -38,6 +39,16 @@ export interface GenerationFunctions {
    * Creates a number rounded to a whole point.
    */
   Int: (...params: any[]) => number;
+
+  /**
+   * Creates a random date in the future.
+   */
+  FutureDate: (...params: any[]) => Date;
+
+  /**
+   * Creates a random date in the past.
+   */
+  PastDate: (...params: any[]) => Date;
 }
 
 /**
@@ -50,6 +61,8 @@ export const dixtureFns: GenerationFunctions = {
   String: createString,
   NamedString: <T>(prefix: keyof T) => createString(prefix.toString()),
   Int: () => createNumber(true),
+  FutureDate: () => createDate(),
+  PastDate: () => createDate(false),
 };
 
 /**

--- a/src/_simpleGenerator.ts
+++ b/src/_simpleGenerator.ts
@@ -90,6 +90,28 @@ export function createBigInt(
   return BigInt(createNumber(true, params));
 }
 
+function createDateWithOffset(daysOffset: number = 0): Date {
+  let result: Date = new Date();
+  result.setDate(result.getDate() + daysOffset);
+  return result;
+}
+
+/**
+ * Creates a random date.
+ * @param isFuture should the date be in the future or in the past
+ * @param params parameters for random number generation
+ */
+export function createDate(
+  isFuture: boolean = true,
+  params: GeneratorParameters = defaultParameters,
+): Date {
+  const modifyBy = createNumber(
+    true,
+    params,
+  );
+  return createDateWithOffset(isFuture ? modifyBy : -1 * modifyBy);
+}
+
 /**
  * Creates and assign a value for a string, boolean, number or bigint field.
  * @param subject object that owns the field

--- a/tests/simpleGenerator_test.ts
+++ b/tests/simpleGenerator_test.ts
@@ -6,7 +6,11 @@ import {
   assertThrows,
   fail,
 } from "./deps.ts";
-import { assignField, createFieldValue } from "../src/_simpleGenerator.ts";
+import {
+  assignField,
+  createFieldValue,
+  createDate,
+} from "../src/_simpleGenerator.ts";
 
 interface Subject {
   aNumericField: number;
@@ -14,6 +18,7 @@ interface Subject {
   aBooleanField: boolean;
   aBigIntField: bigint;
   anUndefinedNumber?: number;
+  aDateField: Date;
 }
 
 Rhum.testPlan("Simple Generator", () => {
@@ -25,6 +30,7 @@ Rhum.testPlan("Simple Generator", () => {
       aNumericField: 42,
       aStringField: "my string",
       aBigIntField: 100n,
+      aDateField: new Date(),
     };
   });
 
@@ -212,6 +218,42 @@ Rhum.testPlan("Simple Generator", () => {
             max: 20,
           })
         );
+      },
+    );
+  });
+
+  Rhum.testSuite("createDate", () => {
+    let refDate: Date;
+
+    Rhum.beforeEach(() => {
+      refDate = new Date();
+    });
+
+    Rhum.testCase(
+      "1. Should create a Date in the future when no parameters are set",
+      () => {
+        const result = createDate();
+        assert(result != null);
+        assert(result > refDate);
+      },
+    );
+
+    Rhum.testCase(
+      "2. Should create a Date in the past when parameters are set",
+      () => {
+        const result = createDate(false);
+        assert(result != null);
+        assert(result < refDate);
+      },
+    );
+
+    Rhum.testCase(
+      "3. Should create a Date within a random range when parameters are set",
+      () => {
+        const result = createDate(true, { max: 365 * 3, min: 365 });
+        assert(result != null);
+        assert(result > refDate);
+        assert(result.getFullYear() > refDate.getFullYear());
       },
     );
   });


### PR DESCRIPTION
This commit allow consumers to generate random Dates using the functions
exposed by dixtureFn.
Squashes the following:

+ feat: Add createDate function to simple generator
+ feat: Add Dates to dixtureFns
+ chore: Update docs and Samples